### PR TITLE
Rename master variable and allow declaring custom packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,4 @@ galera_cluster_nodes:
 galera_provider_options: 'pc.ignore_quorum=true; gcache.size=1G'
 galera_retry_autocommit: 10
 galera_slave_threads: 8
+galera_packages: []

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -4,13 +4,13 @@
   service:
     name={{ mariadb_svc_name }}
     state=restarted
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master
 
 - name: Syncing other nodes to the master
   service:
     name={{ mariadb_svc_name }}
     state=restarted
-  when: inventory_hostname != master
+  when: inventory_hostname != galera_master
 
 - name: Set gcomm:// on the master node
   lineinfile:
@@ -18,4 +18,4 @@
     state=present
     regexp='^wsrep_cluster_address='
     line='wsrep_cluster_address=gcomm://{{ ",".join(galera_cluster_nodes) }}'
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,7 +9,7 @@
   service:
     name={{ mariadb_svc_name }}
     state=started
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master
 
 - include: configurations/Debian.yml
   when: ansible_os_family == 'Debian'

--- a/tasks/configurations/Debian.yml
+++ b/tasks/configurations/Debian.yml
@@ -6,7 +6,7 @@
     password={{ mariadb_root_password }}
     host=localhost
     state=present
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master
 
 - name: Creating the final /root/.my.cnf file (Debian family)
   template:
@@ -20,7 +20,7 @@
     password={{ mariadb_maintenance_password }}
     host=localhost
     state=present
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master
 
 - name: Configuring Galera cluster (1/3) (Debian family)
   template:

--- a/tasks/configurations/RedHat.yml
+++ b/tasks/configurations/RedHat.yml
@@ -13,7 +13,7 @@
     password={{ mariadb_root_password }}
     host=localhost
     state=present
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master
 
 - name: Creating the /root/.my.cnf file (RedHat family)
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,21 @@
     - galera-install
     - galera-pacemaker
 
+- include_vars: "{{ ansible_os_family }}_packages.yml"
+  tags:
+    - galera
+    - galera-bootstrap
+    - galera-config 
+    - galera-firewall
+    - galera-repo
+    - galera-reset
+    - galera-secure
+    - galera-selinux
+    - galera-users
+    - galera-install
+    - galera-pacemaker
+  when: galera_packages | length == 0
+
 - include: reset.yml
   when: galera_reset_cluster is defined and
         galera_reset_cluster == true

--- a/tasks/pacemaker.yml
+++ b/tasks/pacemaker.yml
@@ -6,7 +6,7 @@
     password={{ galera_clustercheck_password }}
     priv=*.*:USAGE
     state=present
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master
 
 - name: Creating /etc/(sysconfig|default)/clustercheck file (ready for Pacemaker)
   template:

--- a/tasks/secure.yml
+++ b/tasks/secure.yml
@@ -4,7 +4,7 @@
   mysql_db:
     name: test
     state: absent
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master
 
 - name: Disabling remote access for root
   mysql_user:
@@ -14,10 +14,10 @@
     - 'localhost'
     - '127.0.0.1'
     - '::1'
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master
 
 - name: Disabling anonymous access
   mysql_user:
     name: ""
     state: absent
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -6,4 +6,4 @@
     password={{ galera_sst_password }}
     priv=*.*:ALL,GRANT
     state=present
-  when: inventory_hostname == master
+  when: inventory_hostname == galera_master

--- a/templates/etc/my.cnf.d/galera.cnf.j2
+++ b/templates/etc/my.cnf.d/galera.cnf.j2
@@ -19,7 +19,7 @@ wsrep_provider_options="{{ galera_provider_options | default('pc.ignore_quorum=t
 
 # Galera Cluster Configuration
 wsrep_cluster_name="{{ galera_cluster_name | default('uoi-sql-cluster') }}"
-{% if inventory_hostname == master %}
+{% if inventory_hostname == galera_master %}
 wsrep_cluster_address="gcomm://"
 {% else %}
 wsrep_cluster_address="gcomm://{{ ",".join(galera_cluster_nodes) }}"

--- a/templates/etc/mysql/conf.d/galera.cnf.j2
+++ b/templates/etc/mysql/conf.d/galera.cnf.j2
@@ -4,7 +4,7 @@ wsrep_provider={{ galera_provider }}
 wsrep_provider_options="{{ galera_provider_options | default('pc.ignore_quorum=true') }}"
 wsrep_cluster_name={{ galera_cluster_name | default('uoi-sql-cluster') }}
 wsrep_sst_auth={{ galera_sst_user }}:{{ galera_sst_password }}
-{% if (inventory_hostname == master) %}
+{% if (inventory_hostname == galera_master) %}
 wsrep_cluster_address=gcomm://
 {% else %}
 wsrep_cluster_address=gcomm://{{ ",".join(galera_cluster_nodes) }}

--- a/vars/CentOS_packages.yml
+++ b/vars/CentOS_packages.yml
@@ -1,0 +1,11 @@
+---
+galera_packages:
+  - MariaDB-server
+  - percona-xtrabackup
+  - socat
+  - MySQL-python
+  - percona-toolkit
+  - galera
+  - policycoreutils-python
+  - checkpolicy
+  - xinetd

--- a/vars/Debian_packages.yml
+++ b/vars/Debian_packages.yml
@@ -1,0 +1,8 @@
+---
+galera_packages:
+  - mariadb-server
+  - xtrabackup
+  - socat
+  - python-mysqldb
+  - percona-toolkit
+  - xinetd

--- a/vars/RedHat_packages.yml
+++ b/vars/RedHat_packages.yml
@@ -1,0 +1,11 @@
+---
+galera_packages:
+  - MariaDB-server
+  - percona-xtrabackup
+  - socat
+  - MySQL-python
+  - percona-toolkit
+  - galera
+  - policycoreutils-python
+  - checkpolicy
+  - xinetd


### PR DESCRIPTION
Some other roles or playbooks might use a variable name as generic as *master*, and I found my self in this situation, so I suggest this simple change that doesn't cause any issue.
And sorry to have it together, but I also make a change to have custom packages if specified (so I can set the ones for Ubuntu Jammy, but old Ubuntu distros have also different names).
I could split this two changes in another PR (but it might take some time since I don't really need them :) )